### PR TITLE
Fixed behaviour on borders

### DIFF
--- a/guidedfilter.cpp
+++ b/guidedfilter.cpp
@@ -3,7 +3,7 @@
 static cv::Mat boxfilter(const cv::Mat &I, int r)
 {
     cv::Mat result;
-    cv::blur(I, result, cv::Size(r, r));
+    cv::blur(I, result, cv::Size(r, r), cv::Point(-1, -1), cv::BORDER_REPLICATE);
     return result;
 }
 


### PR DESCRIPTION
cv::blur fixed: border should be REPLICATE instead of default=REFLECT_101 (see OpenCV documentation for [blur](https://docs.opencv.org/4.3.0/d4/d86/group__imgproc__filter.html#ga8c45db9afe636703801b0b2e440fce37), for OpenCV 2.x and 3.x it is the same).

Below comparison of:
 - original cat image
 - ```cv::blur(cat, result, cv::Size(15, 15))``` (i.e. ```cv::BORDER_DEFAULT = BORDER_REFLECT_101```)
 - ```cv::blur(cat, result, cv::Size(15, 15), cv::Point(-1, -1), cv::BORDER_REPLICATE)```

![Original](https://github.com/PolarNick239/polarnick239.github.io/raw/master/static/2020/01/cat.png)

![blur(15, BORDER_REFLECT_101)](https://github.com/PolarNick239/polarnick239.github.io/raw/master/static/2020/01/cat_boxfilter15_BORDER_DEFAULT.png) ![blur(15, BORDER_REPLICATE)](https://github.com/PolarNick239/polarnick239.github.io/raw/master/static/2020/01/cat_boxfilter15_BORDER_REPLICATE.png)